### PR TITLE
Fix 404 page on storybook preview instances

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -100,7 +100,7 @@ runs:
           :---:
 
           :rocket: Deployed preview to
-          https://${{ env.pagesurl }}/${{ env.targetdir }}
+          https://${{ env.pagesurl }}/${{ env.targetdir }}/
 
           on branch [`${{ inputs.preview-branch }}`](\
           ${{ github.server_url }}/${{ github.repository }}\


### PR DESCRIPTION
The generated URL does not work in every scenario.

In my case I want to create a preview of storybook. The generated URL does not work directly and redirects to a 404 page. If I add a slash manually at the end of the URL then it works.

This fix is relatively simple and just adds a slash at the end of the preview link. This should also does not break existing links.