### PR TITLE
Move documentation to a Jekyll site

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 package-lock.json
+.vscode/

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,6 @@
+_site
+.sass-cache
+.jekyll-cache
+.jekyll-metadata
+vendor
+Gemfile.lock

--- a/docs/404.md
+++ b/docs/404.md
@@ -1,0 +1,8 @@
+---
+permalink: /404.html
+nav_exclude: true
+---
+
+# 404
+
+The requested page could not be found.

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -1,0 +1,10 @@
+source "https://rubygems.org"
+
+gem "just-the-docs"
+gem "jekyll", "~> 4", group: :jekyll_plugins
+
+group :jekyll_plugins do
+  gem "jekyll-default-layout"
+  gem "jekyll-seo-tag"
+  gem "jekyll-sitemap"
+end

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,29 @@
+title: PR Preview Action
+tagline: A GitHub Action for previewing pull requests
+description: >-
+  Documentation for PR Preview Action, a GitHub Action that deploys pull
+  request previews to GitHub Pages (and removes them after merge).
+baseurl: ""
+url: https://rossjrw.com/
+
+permalink: pretty
+
+author:
+  url: https://rossjrw.com/
+
+theme: just-the-docs
+
+aux_links:
+  GitHub:
+    - "https://github.com/rossjrw/pr-preview-action"
+
+gh_edit_link: true
+gh_edit_link_text: Edit this page on GitHub
+gh_edit_repository: https://github.com/rossjrw/pr-preview-action
+gh_edit_branch: main
+gh_edit_source: docs
+
+ga_tracking: G-19V908BQMY
+
+plugins:
+  - jekyll-seo-tag

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,3 @@
+---
+layout: home
+---


### PR DESCRIPTION
Instead of wasting time documenting the changes I'm making in #6 in either the current format or a new temporary one, I may as well take this opportunity to move everything to a Jekyll site.

- [ ] Move main docs to a Jekyll site
- [ ] Change build and preview processes to be for this site
- [ ] Create an equivalent of #1 (or rebase it) to preview changes for this site
- [ ] Use includes for the yml files while still keeping them as independent files

Merges into #6.

(edit: just in case anyone is wondering why this PR has been open so long, I did a whole lot of work on this and then that computer got wiped in an unrelated incident. push regularly!)