### PR TITLE
Update action to work with user/organization sites

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -55,9 +55,16 @@ runs:
         echo "targetdir=$umbrella/pr-$pr" >> $GITHUB_ENV
         echo "pr=$pr" >> $GITHUB_ENV
 
-        pagesurl=$(echo $GITHUB_REPOSITORY | sed 's/\//.github.io\//')
-        echo "pagesurl=$pagesurl" >> $GITHUB_ENV
+        org=$(echo "$GITHUB_REPOSITORY" | cut -d "/" -f 1)
+        thirdleveldomain=$(echo "$GITHUB_REPOSITORY" | cut -d "/" -f 2 | cut -d "." -f 1)
 
+        if [ "$org" == "$thirdleveldomain" ]; then
+          pagesurl="${org}.github.io"
+        else
+          pagesurl=$(echo "$GITHUB_REPOSITORY" | sed 's/\//.github.io\//')
+        fi
+
+        echo "pagesurl=$pagesurl" >> $GITHUB_ENV
 
         echo "emptydir=$(mktemp -d)" >> $GITHUB_ENV
         echo "datetime=$(date '+%Y-%m-%d %H:%M %Z')" >> $GITHUB_ENV


### PR DESCRIPTION
@rossjrw This action currently does not work with organization or user sites. Since the format for user/org sites is different from project sites, it will attempt to deploy to ORG_NAME.github.io/ORG_NAME.github.io/UMBRELLA_FOLDER which just redirects to ORG_NAME.github.io. I added some logic to check whether the repo belongs to an org/user site & create the pagesurl var accordingly. Otherwise it will use the current sed command to create the pagesurl var.