### PR TITLE
fix: rename event_type to event_name

### DIFF
--- a/lib/determine-auto-action.sh
+++ b/lib/determine-auto-action.sh
@@ -2,7 +2,7 @@
 
 case $GITHUB_EVENT_NAME in
   "pull_request" | "pull_request_target")
-    echo "event_type is $GITHUB_EVENT_NAME; proceeding"
+    echo "event_name is $GITHUB_EVENT_NAME; proceeding"
     ;;
   *)
     echo "unknown event $GITHUB_EVENT_NAME; no action to take"


### PR DESCRIPTION
Thank you very much for providing a good library.
I tried it and it's really good.

One thing I found inconvenient while checking the log.

![image](https://user-images.githubusercontent.com/69495129/213419028-ad631335-532d-4c4f-b56d-d910e3500034.png)


I was confused because I specified other variables as event_type together.

Thank you again!