### PR TITLE
Deprecate set-output

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -108,7 +108,7 @@ runs:
 
     - name: Expose deployment URL
       id: url
-      run: echo "::set-output name=url::https://${{ env.pagesurl }}/${{ env.targetdir }}/"
+      run: echo "url=https://${{ env.pagesurl }}/${{ env.targetdir }}/"  >> $GITHUB_OUTPUT
       shell: bash
 
     - name: Leave a comment after deployment


### PR DESCRIPTION
I noticed deprecation warning on `set-out` and followed the documentaiton here: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

I'm not sure experienced in solving such issues, so I wasn't sure how to test it, and suggestions on how to proceed would be welcome. 