### PR TITLE
fix: use git_ref verbatim in event of tag determination failure

### DIFF
--- a/lib/find-current-git-tag.sh
+++ b/lib/find-current-git-tag.sh
@@ -6,7 +6,7 @@ helpFunction() {
   echo -e "\t-p GitHub repository to clone, format: owner/repo"
   echo -e "\t-f Reference of repository to clone"
   exit 1
-}
+} >&2
 
 while getopts "p:f:" opt; do
   case "$opt" in
@@ -17,17 +17,18 @@ while getopts "p:f:" opt; do
 done
 
 if [ -z "$github_repository" ] || [ -z "$git_ref" ]; then
-  echo "some parameters are empty"
+  echo >&2 "some parameters are empty"
   helpFunction
 fi
 
-echo "Cloning repository $github_repository at ref $git_ref"
-git clone --bare --single-branch --branch "$git_ref" "https://github.com/$github_repository" bare_pr_preview && {
-  action_version=$(git describe --tags --match "v*.*.*" \
-    || git describe --tags \
-    || git rev-parse HEAD)
-
-  echo "action_version=$action_version" >> "$GITHUB_ENV"
-} || {
-  echo "action_version=$git_ref" >> "$GITHUB_ENV"
-}
+echo >&2 "Determining preview action version"
+echo >&2 "Cloning repository $github_repository at ref $git_ref"
+if git clone --bare --single-branch --branch "$git_ref" "https://github.com/$github_repository" bare_pr_preview; then
+  echo >&2 "Finding most specific tag matching tag $git_ref"
+  action_version=$(git describe --tags --match "v*.*.*" || git describe --tags || git rev-parse HEAD)
+  echo >&2 "Found $action_version"
+  echo "action_version=$action_version" >>"$GITHUB_ENV"
+else
+  echo >&2 "Clone failed; using truncated ref as action version"
+  echo "action_version=${git_ref:0:9}" >>"$GITHUB_ENV"
+fi

--- a/lib/find-current-git-tag.sh
+++ b/lib/find-current-git-tag.sh
@@ -22,12 +22,12 @@ if [ -z "$github_repository" ] || [ -z "$git_ref" ]; then
 fi
 
 echo "Cloning repository $github_repository at ref $git_ref"
-git clone --bare --single-branch --branch "$git_ref" "https://github.com/$github_repository" bare_pr_preview
+git clone --bare --single-branch --branch "$git_ref" "https://github.com/$github_repository" bare_pr_preview && {
+  action_version=$(git describe --tags --match "v*.*.*" \
+    || git describe --tags \
+    || git rev-parse HEAD)
 
-cd bare_pr_preview || exit 1
-
-action_version=$(git describe --tags --match "v*.*.*" \
-  || git describe --tags \
-  || git rev-parse HEAD)
-
-echo "action_version=$action_version" >> "$GITHUB_ENV"
+  echo "action_version=$action_version" >> "$GITHUB_ENV"
+} || {
+  echo "action_version=$git_ref" >> "$GITHUB_ENV"
+}


### PR DESCRIPTION
The action will fail if someone tries to use it with a SHA instead of a tag, e.g., `uses: rossjrw/pr-preview-action@9dac5c4777c535516ebf819f93aeadac70f66488` because the script cannot determine the tag from this SHA.

This changes the action to just use the SHA if the tag cannot be determined.  Another approach would be to eliminate this script entirely, as it is only used for display of the version in the generated PR comment.