### PR TITLE
Restrict permissions of GitHub Actions

### DIFF
--- a/.github/workflows/deploy-example.yml
+++ b/.github/workflows/deploy-example.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches:
       - main
+permissions:
+  contents: write
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/preview-example.yml
+++ b/.github/workflows/preview-example.yml
@@ -6,6 +6,9 @@ on:
       - reopened
       - synchronize
       - closed
+permissions:
+  contents: write
+  pull-requests: write
 concurrency: preview-${{ github.ref }}
 jobs:
   deploy-preview:

--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ on:
       - synchronize
       - closed
 
+permissions:
+  contents: write
+  pull-requests: write
+
 concurrency: preview-${{ github.ref }}
 
 jobs:
@@ -104,13 +108,6 @@ for the `pull_request` event. It only comes with `opened`, `reopened`, and
 `synchronize` by default &mdash; but this Action assumes by default that
 the preview should be removed during the `closed` event, which it only sees
 if you explicitly add it to the workflow.
-
-#### Grant Actions permission to read and write to the repository
-
-This must be changed in the repository settings by selecting "Read and
-write permissions" at **Settings** > **Actions** > **General** >
-**Workflow permissions**. Otherwise, the Action won't be able to make any
-changes to your deployment branch.
 
 #### Set a concurrency group
 
@@ -262,6 +259,9 @@ on:
       - reopened
       - synchronize
       - closed
+permissions:
+  contents: write
+  pull-requests: write
 jobs:
   deploy-preview:
     runs-on: ubuntu-latest
@@ -285,6 +285,8 @@ on:
   push:
     branches:
       - main
+permissions:
+  contents: write
 jobs:
   deploy-preview:
     runs-on: ubuntu-latest
@@ -354,6 +356,9 @@ on:
     types:
       - opened
       - synchronize
+permissions:
+  contents: write
+  pull-requests: write
 jobs:
   deploy-preview:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
It appears that [the default permissions on `GITHUB_TOKEN` have been changed to read-only](https://github.blog/changelog/2023-02-02-github-actions-updating-the-default-github_token-permissions-to-read-only/). By default, we cannot use this action until we change the settings of `Workflow permissions` to `Read and write permissions`.
However, `Read and write permissions` are too much for this action. I think it should be for `contents` and `pull-requests` only.
[JamesIves/github-pages-deploy-action](https://github.com/JamesIves/github-pages-deploy-action) requires write permission for `contents` and [marocchino/sticky-pull-request-comment](https://github.com/marocchino/sticky-pull-request-comment) requires write permission for `pull-requests`.

This is my first contribution to OSS, so please let me know if I am wrong.

<img width="787" alt="スクリーンショット 2023-04-09 10 48 32" src="https://user-images.githubusercontent.com/104971044/230750088-dced806d-0466-40c2-95c3-7b92d8a6c776.png">
