### PR TITLE
feat: allow to specify a different repository to deploy to

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,22 @@ the `with` parameter.
   Default: Will attempt to calculate the repository's GitHub Pages URL
   (e.g. "rossjrw.github.io").
 
+- `deploy-repository`: The repository to deploy the preview to.
+
+  If this value is changed from the default, the `token` parameter must also
+  be set (see below).
+
+  Default: The current repository that the pull request was made in.
+
+- `token`: The token to use for the preview deployment. The default value is
+  fine for most purposes, but if you want to deploy the preview to a different
+  repository (see `deploy-repository` above), you will need to create a
+  [Personal Access Token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token)
+  with permission to access it.
+
+  Default: GITHUB_TOKEN, which gives the action permission to deploy to the
+  current repository.
+
 - **(Advanced)** `action`: Determines what this action will do when it is
   executed. Supported values: `deploy`, `remove`, `none`, `auto`.
 

--- a/action.yml
+++ b/action.yml
@@ -11,8 +11,10 @@ branding:
 inputs:
   token:
     description: >
-      Default is GITHUB_TOKEN in the repository.
-      If you need more permissions for things such as deploying to another repository, you can add a PAT.
+      The token to use for the deployment.
+      Default is GITHUB_TOKEN in the current repository.
+      If you need more permissions for things such as deploying to another
+      repository, you can add a Personal Access Token (PAT).
     required: false
     default: ${{ github.token }}
   preview-branch:
@@ -29,9 +31,14 @@ inputs:
     default: .
   deploy-repository:
     description: >
-      You can deploy to GitHub Pages in the different repository.
-      This should be formatted like so: `rossjrw/pr-preview-action` .
-      You'll need to use PAT in the `token` input.
+      The GitHub repository to deploy the preview to.
+      This should be formatted like `<org name>/<repo name>`, e.g.
+      `rossjrw/pr-preview-action`.
+      Defaults to the current repository.
+
+      You will need to add a Personal Access Token (PAT) in the `token` input
+      in order to allow the action running in one repository to make changes
+      to another repository.
     required: false
     default: ${{ github.repository }}
   custom-url:

--- a/action.yml
+++ b/action.yml
@@ -33,7 +33,7 @@ inputs:
       This should be formatted like so: `rossjrw/pr-preview-action` .
       You'll need to use PAT in the `token` input.
     required: false
-    default: ${{ env.GITHUB_REPOSITORY }}
+    default: ${{ github.repository }}
   custom-url:
     description: Custom pages URL
     required: false
@@ -80,15 +80,15 @@ runs:
         echo "targetdir=$umbrella/pr-$pr" >> $GITHUB_ENV
         echo "pr=$pr" >> $GITHUB_ENV
 
-        org=$(echo "$GITHUB_REPOSITORY" | cut -d "/" -f 1)
-        thirdleveldomain=$(echo "$GITHUB_REPOSITORY" | cut -d "/" -f 2 | cut -d "." -f 1)
+        org=$(echo "$deployrepo" | cut -d "/" -f 1)
+        thirdleveldomain=$(echo "$deployrepo" | cut -d "/" -f 2 | cut -d "." -f 1)
 
         if [ ! -z "$customurl" ]; then
           pagesurl="$customurl"
         elif [ "$org" == "$thirdleveldomain" ]; then
           pagesurl="${org}.github.io"
         else
-          pagesurl=$(echo "$GITHUB_REPOSITORY" | sed 's/\//.github.io\//')
+          pagesurl=$(echo "$deployrepo" | sed 's/\//.github.io\//')
         fi
 
         echo "pagesurl=$pagesurl" >> $GITHUB_ENV

--- a/action.yml
+++ b/action.yml
@@ -9,6 +9,12 @@ branding:
   color: yellow
 
 inputs:
+  token:
+    description: >
+      Default is GITHUB_TOKEN in the repository.
+      If you need more permissions for things such as deploying to another repository, you can add a PAT.
+    required: false
+    default: ${{ github.token }}
   preview-branch:
     description: Branch on which the previews will be deployed.
     required: false
@@ -21,6 +27,13 @@ inputs:
     description: Directory containing files to deploy.
     required: false
     default: .
+  deploy-repository:
+    description: >
+      You can deploy to GitHub Pages in the different repository.
+      This should be formatted like so: `rossjrw/pr-preview-action` .
+      You'll need to use PAT in the `token` input.
+    required: false
+    default: ${{ env.GITHUB_REPOSITORY }}
   custom-url:
     description: Custom pages URL
     required: false
@@ -60,6 +73,8 @@ runs:
         actionref: ${{ github.action_ref }}
         actionrepo: ${{ github.action_repository }}
         customurl: ${{ inputs.custom-url }}
+        deployrepo: ${{ inputs.deploy-repository }}
+        token: ${{ inputs.token }}
       run: |
         echo "action=$action" >> $GITHUB_ENV
         echo "targetdir=$umbrella/pr-$pr" >> $GITHUB_ENV
@@ -83,6 +98,8 @@ runs:
 
         echo "actionref=$actionref" >> $GITHUB_ENV
         echo "actionrepo=$actionrepo" >> $GITHUB_ENV
+        echo "deployrepo=$deployrepo" >> $GITHUB_ENV
+        echo "token=$token" >> $GITHUB_ENV
       shell: bash
 
     - name: Determine action version
@@ -100,6 +117,8 @@ runs:
       if: env.action == 'deploy'
       uses: JamesIves/github-pages-deploy-action@v4
       with:
+        token: ${{ env.token }}
+        repository-name: ${{ env.deployrepo }}
         branch: ${{ inputs.preview-branch }}
         folder: ${{ inputs.source-dir }}
         target-folder: ${{ env.targetdir }}
@@ -136,6 +155,8 @@ runs:
       if: env.action == 'remove'
       uses: JamesIves/github-pages-deploy-action@v4
       with:
+        token: ${{ env.token }}
+        repository-name: ${{ env.deployrepo }}
         branch: ${{ inputs.preview-branch }}
         folder: ${{ env.emptydir }}
         target-folder: ${{ env.targetdir }}


### PR DESCRIPTION
Resolves #41

## Description
Thank you for creating this fantastic action!
I've added a feature to deploy previews to GitHub Pages of another repository. The following inputs have been added:

- deploy-repository ... Specify the repository name to deploy. This is an input that can be passed to JamesIves/github-pages-deploy-action. The default is github.repository.
- token ... The default `GITHUB_TOKEN` does not have enough permissions since it will be pushing to another repository. Therefore, the ability to pass a token is added.

These inputs are passed to JamesIves/github-pages-deploy-action.

Also, the `pagesurl` can be changed to the repository to deploy to.

## Motivation
On the site I manage, I deploy to GitHub Pages using the beta version of GitHub Actions.
As a result, I'm facing the same problem as in this issue: https://github.com/rossjrw/pr-preview-action/issues/21, and I would like to deploy the preview environment to another repository as a workaround.

## Verification
I have prepared the following two repositories and verified the operation:

- source repo ... https://github.com/MH4GF/test-pr-preview-source
    - workflows ... https://github.com/MH4GF/test-pr-preview-source/actions/workflows/deploy-preview.yml
- target repo ... https://github.com/MH4GF/test-pr-review-target
- preview(target repo) ... https://mh4gf.github.io/test-pr-review-target/pr-preview/pr-3/
- preview(source repo, check regression) ... https://mh4gf.github.io/test-pr-preview-source/pr-preview/pr-3/