### PR TITLE
Update to #24 to limit mismatches for org pages

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -66,11 +66,11 @@ runs:
         echo "pr=$pr" >> $GITHUB_ENV
 
         org=$(echo "$GITHUB_REPOSITORY" | cut -d "/" -f 1)
-        thirdleveldomain=$(echo "$GITHUB_REPOSITORY" | cut -d "/" -f 2 | cut -d "." -f 1)
+        thirdleveldomain=$(echo "$GITHUB_REPOSITORY" | cut -d "/" -f 2)
 
         if [ ! -z "$customurl" ]; then
           pagesurl="$customurl"
-        elif [ "$org" == "$thirdleveldomain" ]; then
+        elif [ "${org}.github.io" == "$thirdleveldomain" ]; then
           pagesurl="${org}.github.io"
         else
           pagesurl=$(echo "$GITHUB_REPOSITORY" | sed 's/\//.github.io\//')


### PR DESCRIPTION
When the repository matches the org name, which might be slightly more
common for small OSS projects where the owner wishes to move to using an
org to allow it be managed by other contributors over time, the existing
code will assume this means it is for the org level pages.

Consequently updates to a repo such as vagrant-libvirt/vagrant-libvirt
will have it's preview URL using the org style rather than the
repository style.

This change adjust the matching to limit to only allowing repos of the
name `<org>.github.io` to be presented with the org style gh-pages
preview URL.

Fixes #39
