### PR TITLE
Fix link to preview branch

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -153,7 +153,7 @@ runs:
           https://${{ env.pagesurl }}/${{ env.targetdir }}/
 
           on branch [`${{ inputs.preview-branch }}`](\
-          ${{ github.server_url }}/${{ github.repository }}\
+          ${{ github.server_url }}/${{ env.deployrepo }}\
           /tree/${{ inputs.preview-branch }})
           at ${{ env.datetime }}
           "


### PR DESCRIPTION
When appending the message to the pull request after deploying the preview, the link to the branch is wrong as it uses the wrong repo. Instead of deployrepo the repo of the pull request is used.