### PR TITLE
Support retrieving latest version tag also when pinning action

### DIFF
--- a/lib/find-current-git-tag.sh
+++ b/lib/find-current-git-tag.sh
@@ -24,11 +24,11 @@ fi
 echo >&2 "Determining Git tag for $github_repository/$git_ref"
 
 echo >&2 "Cloning repository $github_repository at ref $git_ref"
-git clone --bare --single-branch --branch "$git_ref" "https://github.com/$github_repository" bare_pr_preview
+git clone --bare  "https://github.com/$github_repository" bare_pr_preview
 
 cd bare_pr_preview || exit 1
 
-action_version=$(git describe --tags --match "v*.*.*" || git describe --tags || git rev-parse HEAD)
+action_version=$(git describe --tags --match "v*.*.*" "$git_ref" || git describe --tags "$git_ref" || git rev-parse HEAD)
 
 echo "$action_version"
 exit 0


### PR DESCRIPTION
This fixes #67 .

Right now, the action can not be pinned, this PR fixes that so that the referenced tag can also be determined from a commit hash.