### PR TITLE
chore: use fixed hashes for the dependency actions

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -122,7 +122,7 @@ runs:
 
     - name: Deploy preview directory
       if: env.action == 'deploy'
-      uses: JamesIves/github-pages-deploy-action@v4
+      uses: JamesIves/github-pages-deploy-action@65b5dfd4f5bcd3a7403bbc2959c144256167464e
       with:
         token: ${{ env.token }}
         repository-name: ${{ env.deployrepo }}
@@ -139,7 +139,7 @@ runs:
 
     - name: Leave a comment after deployment
       if: env.action == 'deploy' && env.deployment_status == 'success'
-      uses: marocchino/sticky-pull-request-comment@v2
+      uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31
       with:
         header: pr-preview
         message: "\
@@ -160,7 +160,7 @@ runs:
 
     - name: Remove preview directory
       if: env.action == 'remove'
-      uses: JamesIves/github-pages-deploy-action@v4
+      uses: JamesIves/github-pages-deploy-action@65b5dfd4f5bcd3a7403bbc2959c144256167464e
       with:
         token: ${{ env.token }}
         repository-name: ${{ env.deployrepo }}
@@ -172,7 +172,7 @@ runs:
 
     - name: Leave a comment after removal
       if: env.action == 'remove' && env.deployment_status == 'success'
-      uses: marocchino/sticky-pull-request-comment@v2
+      uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31
       with:
         header: pr-preview
         message: "\


### PR DESCRIPTION
Thanks for this great action!

Since the action is dependent on some other actions (`JamesIves/github-pages-deploy-action@v4`, `marocchino/sticky-pull-request-comment@v2`), it may be succeptible to some supply chain attacks, see here: https://www.rwx.com/blog/github-actions-is-vulnerable-to-supply-chain-attacks

Some malicious actor could take over the mentioned dependencies and change the v2 release to any arbitrary release without anyone noticing. That's why it's a good practice to pin your actions and their dependencies (some orgs even enforce this). 

When pinning this action to a specific commit in the repo settings, you still need to pin the dependencies to `v2` / `v4` and cannot set them to a specific commit since the action definition requires versions.

This PR mitigates the supply chain attack risk by pinning all dependencies to a specific version. I understand that this slightly increases maintenance efforts, as minor- and patch- updates to the upstream actions need to be done by hand. However, I advocate that in the spirit of security, this change is useful. Please LMK your thougts.