### PR TITLE
Allow for serving GitHub pages from non root directory

### DIFF
--- a/.github/workflows/preview-example.yml
+++ b/.github/workflows/preview-example.yml
@@ -10,6 +10,8 @@ concurrency: preview-${{ github.ref }}
 jobs:
   deploy-preview:
     runs-on: ubuntu-latest
+    # Only run if this PR is not from a fork
+    if: github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,14 @@
+name: Run tests
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Run tests
+        run: |
+          set -e
+          for testscript in test/test-*.sh; do
+            bash $testscript
+          done

--- a/README.md
+++ b/README.md
@@ -347,6 +347,7 @@ steps:
       source-dir: build
       preview-branch: main
       umbrella-dir: docs/pr-preview
+      pages-base-dir: docs
 ```
 
 You should definitely limit this workflow to run only on changes to

--- a/README.md
+++ b/README.md
@@ -339,7 +339,7 @@ steps:
       source-dir: build
       preview-branch: main
       umbrella-dir: docs/pr-preview
-      pages-base-dir: docs
+      pages-base-path: docs
 ```
 
 You should definitely limit this workflow to run only on changes to

--- a/README.md
+++ b/README.md
@@ -220,6 +220,19 @@ the `with` parameter.
 
   Default: `pr-preview`
 
+- `pages-base-dir`: Name of the GitHub pages directory being served from.
+
+  The pages base directory is removed from the beginning of your `umrella-dir` path to make sure your preview URL is correct.
+
+  Use the same formatting as your `umbrella-dir`, e.g.
+
+  ```yml
+  umbrella-dir: docs/pr-preview
+  pages-base-dir: docs
+  ```
+
+  Default: ` ` *(ignored unless specified)*
+
 - `custom-url`: Base URL to use when providing a link to the preview site.
 
   Default: Will attempt to calculate the repository's GitHub Pages URL

--- a/README.md
+++ b/README.md
@@ -220,18 +220,9 @@ the `with` parameter.
 
   Default: `pr-preview`
 
-- `pages-base-dir`: Name of the GitHub pages directory being served from.
+- `pages-base-path`: Path that GitHub Pages is being served from, as configured in your repository settings. When generating the preview URL, this is removed from the beginning of the path.
 
-  The pages base directory is removed from the beginning of your `umrella-dir` path to make sure your preview URL is correct.
-
-  Use the same formatting as your `umbrella-dir`, e.g.
-
-  ```yml
-  umbrella-dir: docs/pr-preview
-  pages-base-dir: docs
-  ```
-
-  Default: ` ` *(ignored unless specified)*
+  Default: ` ` (repository root)
 
 - `custom-url`: Base URL to use when providing a link to the preview site.
 

--- a/action.yml
+++ b/action.yml
@@ -110,7 +110,7 @@ runs:
         
         targetdir="$umbrella/pr-$pr"
         echo "targetdir=$targetdir" >> $GITHUB_ENV
-        escapedpages=$(sed 's/[&/\]/\\&/g' <<< "$pagesbase")
+        escapedpages=$(sed 's/[&./\]/\\&/g' <<< "$pagesbase")
         pagespath=$(echo $targetdir | sed -e 's/^'$escapedpages'\/\?//')
         echo "pagespath=$pagespath" >> $GITHUB_ENV
 

--- a/action.yml
+++ b/action.yml
@@ -25,12 +25,8 @@ inputs:
     description: Name of the directory containing all previews.
     required: false
     default: pr-preview
-  pages-base-dir:
-    description: >
-      Directory GitHub is serving your pages from.
-      This will be removed from the beginning  of `umbrella-dir` to get the true path to the preview.
-
-      _Only needed if you are not serving your GitHub pages from the root of the repository._
+  pages-base-path:
+    description: Path that GitHub Pages is served from.
     required: false
     default: ""
   source-dir:
@@ -84,7 +80,7 @@ runs:
       env:
         action: ${{ inputs.action }}
         umbrella: ${{ inputs.umbrella-dir }}
-        pagesbase: ${{ inputs.pages-base-dir }}
+        pagesbase: ${{ inputs.pages-base-path }}
         pr: ${{ github.event.number }}
         actionref: ${{ github.action_ref }}
         actionrepo: ${{ github.action_repository }}

--- a/action.yml
+++ b/action.yml
@@ -162,7 +162,7 @@ runs:
           :---:
 
           :rocket: Deployed preview to
-          https://${{ env.pagesurl }}/${{ env.targetdir }}/
+          https://${{ env.pagesurl }}/${{ env.pagespath }}/
 
           on branch [`${{ inputs.preview-branch }}`](\
           ${{ github.server_url }}/${{ env.deployrepo }}\

--- a/action.yml
+++ b/action.yml
@@ -110,7 +110,9 @@ runs:
         
         targetdir="$umbrella/pr-$pr"
         echo "targetdir=$targetdir" >> $GITHUB_ENV
-        echo "pagespath=${targetdir/"$pagesbase"/}" >> $GITHUB_ENV
+        escapedpages=$(sed 's/[&/\]/\\&/g' <<< "$pagesbase")
+        pagespath=$(echo $targetdir | sed -e 's/^'$escapedpages'//')
+        echo "pagespath=$pagespath" >> $GITHUB_ENV
 
         echo "emptydir=$(mktemp -d)" >> $GITHUB_ENV
         echo "datetime=$(date '+%Y-%m-%d %H:%M %Z')" >> $GITHUB_ENV

--- a/action.yml
+++ b/action.yml
@@ -111,7 +111,7 @@ runs:
         targetdir="$umbrella/pr-$pr"
         echo "targetdir=$targetdir" >> $GITHUB_ENV
         escapedpages=$(sed 's/[&/\]/\\&/g' <<< "$pagesbase")
-        pagespath=$(echo $targetdir | sed -e 's/^'$escapedpages'//')
+        pagespath=$(echo $targetdir | sed -e 's/^'$escapedpages'\/\?//')
         echo "pagespath=$pagespath" >> $GITHUB_ENV
 
         echo "emptydir=$(mktemp -d)" >> $GITHUB_ENV

--- a/action.yml
+++ b/action.yml
@@ -28,7 +28,7 @@ inputs:
   pages-base-dir:
     description: >
       Directory GitHub is serving your pages from.
-      This will be removed from the `umbrella-dir` to get the true path to the preview.
+      This will be removed from the beginning  of `umbrella-dir` to get the true path to the preview.
 
       _Only needed if you are not serving your GitHub pages from the root of the repository._
     required: false

--- a/action.yml
+++ b/action.yml
@@ -103,11 +103,15 @@ runs:
         fi
 
         echo "pagesurl=$pagesurl" >> $GITHUB_ENV
-        
+
         targetdir="$umbrella/pr-$pr"
         echo "targetdir=$targetdir" >> $GITHUB_ENV
-        escapedpages=$(sed 's/[&./\]/\\&/g' <<< "$pagesbase")
-        pagespath=$(echo $targetdir | sed -e 's/^'$escapedpages'\/\?//')
+
+        pagespath=$("$GITHUB_ACTION_PATH/lib/remove-prefix-path.sh" -b "$pagesbase" -o "$targetdir")
+        if [ -n "$pagesbase" ] && [ "$("$GITHUB_ACTION_PATH/lib/remove-prefix-path.sh" -b "" -o "$targetdir")" = "$pagespath" ]; then
+          echo "::warning title=pages-base-path doesn't match::pages-base-path directory ($pagesbase) does not contain umbrella-dir ($umbrella). pages-base-path has been ignored."
+          pagespath=$targetdir
+        fi
         echo "pagespath=$pagespath" >> $GITHUB_ENV
 
         echo "emptydir=$(mktemp -d)" >> $GITHUB_ENV

--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,14 @@ inputs:
     description: Name of the directory containing all previews.
     required: false
     default: pr-preview
+  pages-base-dir:
+    description: >
+      Directory GitHub is serving your pages from.
+      This will be removed from the `umbrella-dir` to get the true path to the preview.
+
+      _Only needed if you are not serving your GitHub pages from the root of the repository._
+    required: false
+    default: ""
   source-dir:
     description: Directory containing files to deploy.
     required: false
@@ -76,6 +84,7 @@ runs:
       env:
         action: ${{ inputs.action }}
         umbrella: ${{ inputs.umbrella-dir }}
+        pagesbase: ${{ inputs.pages-base-dir }}
         pr: ${{ github.event.number }}
         actionref: ${{ github.action_ref }}
         actionrepo: ${{ github.action_repository }}
@@ -84,7 +93,6 @@ runs:
         token: ${{ inputs.token }}
       run: |
         echo "action=$action" >> $GITHUB_ENV
-        echo "targetdir=$umbrella/pr-$pr" >> $GITHUB_ENV
         echo "pr=$pr" >> $GITHUB_ENV
 
         org=$(echo "$deployrepo" | cut -d "/" -f 1)
@@ -99,6 +107,10 @@ runs:
         fi
 
         echo "pagesurl=$pagesurl" >> $GITHUB_ENV
+        
+        targetdir="$umbrella/pr-$pr"
+        echo "targetdir=$targetdir" >> $GITHUB_ENV
+        echo "pagespath=${targetdir/"$pagesbase"/}" >> $GITHUB_ENV
 
         echo "emptydir=$(mktemp -d)" >> $GITHUB_ENV
         echo "datetime=$(date '+%Y-%m-%d %H:%M %Z')" >> $GITHUB_ENV
@@ -134,7 +146,7 @@ runs:
 
     - name: Expose deployment URL
       id: url
-      run: echo "url=https://${{ env.pagesurl }}/${{ env.targetdir }}/"  >> $GITHUB_OUTPUT
+      run: echo "url=https://${{ env.pagesurl }}/${{ env.pagespath }}/"  >> $GITHUB_OUTPUT
       shell: bash
 
     - name: Leave a comment after deployment

--- a/lib/find-current-git-tag.sh
+++ b/lib/find-current-git-tag.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-helpFunction() {
+help() {
   echo ""
   echo "Usage: $0 -p github_repository -f git_ref"
   echo -e "\t-p GitHub repository to clone, format: owner/repo"
@@ -10,21 +10,21 @@ helpFunction() {
 
 while getopts "p:f:" opt; do
   case "$opt" in
-    p) github_repository="$OPTARG" ;;
-    f) git_ref="$OPTARG" ;;
-    ?) helpFunction ;;
+  p) github_repository="$OPTARG" ;;
+  f) git_ref="$OPTARG" ;;
+  ?) help ;;
   esac
 done
 
 if [ -z "$github_repository" ] || [ -z "$git_ref" ]; then
   echo >&2 "some parameters are empty"
-  helpFunction
+  help
 fi
 
 echo >&2 "Determining Git tag for $github_repository/$git_ref"
 
 echo >&2 "Cloning repository $github_repository at ref $git_ref"
-git clone --bare  "https://github.com/$github_repository" bare_pr_preview
+git clone --bare "https://github.com/$github_repository" bare_pr_preview
 
 cd bare_pr_preview || exit 1
 

--- a/lib/remove-prefix-path.sh
+++ b/lib/remove-prefix-path.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+set -e
+
+help() {
+  echo ""
+  echo "Removes a base path from the start of another path."
+  echo "Usage: $0 -b base_path -o original_path"
+  echo -e "\t-b Base path to remove"
+  echo -e "\t-o Path to remove base path from; must start with base path"
+  exit 1
+} >&2
+
+while getopts "b:o:" opt; do
+  case "$opt" in
+  b) base_path="$OPTARG" ;;
+  o) original_path="$OPTARG" ;;
+  ?) help ;;
+  esac
+done
+
+# Remove leading dotslash, leading/trailing slash; collapse multiple slashes
+normalise_path() {
+  echo "$1" | sed -e 's|^\./||g' -e 's|^/||g' -e 's|/*$||g' -e 's|//*|/|g'
+}
+
+base_path=$(normalise_path "$base_path")
+original_path=$(normalise_path "$original_path")
+
+echo "${original_path#"$base_path"/}"
+exit 0

--- a/test/test-remove-prefix-path.sh
+++ b/test/test-remove-prefix-path.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+set -e
+
+echo >&2 "$0: start"
+
+testscript=$(dirname "$0")/../lib/remove-prefix-path.sh
+
+assert() {
+  echo >&2 "$1" = "$2"
+  if [ "$1" != "$2" ]; then
+    echo >&2 "$0: fail"
+    exit 1
+  fi
+}
+
+assert "$($testscript -b "" -o "")" ""
+assert "$($testscript -b "" -o a/b/c/d)" a/b/c/d
+assert "$($testscript -b "/" -o a/b/c/d)" a/b/c/d
+assert "$($testscript -b "/" -o /a/b/c/d)" a/b/c/d
+assert "$($testscript -b "//" -o /a/b/c/d)" a/b/c/d
+assert "$($testscript -b a/b -o a/b/c/d)" c/d
+assert "$($testscript -b ./a/b/ -o a/b/c/d)" c/d
+assert "$($testscript -b a/b -o ./a/b/c/d/)" c/d
+assert "$($testscript -b ./a//b// -o ./a//b//c//d/)" c/d
+assert "$($testscript -b .//a/b -o ./a/b/c/d)" c/d
+assert "$($testscript -b /a/b -o a/b/c/d)" c/d
+assert "$($testscript -b /a/b/ -o /a/b/c/d/)" c/d
+assert "$($testscript -b a/b -o /a/b/c/d)" c/d
+assert "$($testscript -b a/b -o c/d/a/b)" c/d/a/b
+
+# If there is no match, replacement with nothing should return the same result
+assert "$($testscript -b "e/f" -o a/b/c/d)" "$($testscript -b "" -o a/b/c/d)"
+
+echo >&2 "$0: ok"


### PR DESCRIPTION
### Description:
Will allow for generating a URL to the correct preview when serving GitHub pages from any directory other than the root directory.

Adds a new optional param which will be removed from `umbrella-dir` to determine the correct path to the preview.

### Related issues:
closes #42 

### Notes:
Let me know if you think there might be a better approach to this.