### PR TITLE
docs: add add force:false to full example

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,7 @@ jobs:
           folder: .
           branch: gh-pages
           clean-exclude: pr-preview
+          force: false
 ```
 
 ### Deployment from `docs/`


### PR DESCRIPTION
The description above mentions using force:false is recommended when using the deploy action together with the preview action. I've modified the example to also reflect this recommendation.