### PR TITLE
KB-271 - allow support for custom comments and comment headers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "weekly"
+    # Prefix can be max 50 chars
+    commit-message:
+      prefix: "[DAT-15011] [gha]"
+      include: "scope"

--- a/action.yml
+++ b/action.yml
@@ -53,7 +53,7 @@ inputs:
   custom-url:
     description: Custom pages URL
     required: false
-    default: ""
+    default: pr-preview
   action:
     description: >
       Determines what this action will do when it is executed. Supported
@@ -72,6 +72,10 @@ inputs:
       all other events. `auto` is the default value.
     required: false
     default: auto
+  custom-header:
+    description: Optional custom header for PR comments
+    required: false
+    default: ""
 
 outputs:
   deployment-url:
@@ -151,7 +155,7 @@ runs:
       if: env.action == 'deploy' && env.deployment_status == 'success'
       uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 # v2.9.0
       with:
-        header: pr-preview
+        header: ${{ inputs.custom-header }}
         message: "\
           [PR Preview Action]\
           (${{ github.server_url }}/${{ env.actionrepo }})
@@ -185,7 +189,7 @@ runs:
       if: env.action == 'remove' && env.deployment_status == 'success'
       uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 # v2.9.0
       with:
-        header: pr-preview
+        header: ${{ inputs.custom-header }}
         message: "\
           [PR Preview Action]\
           (${{ github.server_url }}/${{ env.actionrepo }})

--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,15 @@ inputs:
       repository, you can add a Personal Access Token (PAT).
     required: false
     default: ${{ github.token }}
+  ssh-key:
+    description: >
+      This option allows you to define a private SSH key to be used in conjunction with a repository deployment key to deploy using SSH.
+      The private key should be stored in the `secrets / with` menu **as a secret**. The public should be stored in the repositories deployment
+      keys menu and be given write access.
+
+      Alternatively you can set this field to `true` to enable SSH endpoints for deployment without configuring the ssh client. This can be useful if you've
+      already setup the SSH client using another package or action in a previous step.
+    required: false    
   preview-branch:
     description: Branch on which the previews will be deployed.
     required: false
@@ -125,6 +134,7 @@ runs:
       uses: JamesIves/github-pages-deploy-action@65b5dfd4f5bcd3a7403bbc2959c144256167464e # v4.5.0
       with:
         token: ${{ env.token }}
+        ssh-key: ${{ inputs.ssh-key }}        
         repository-name: ${{ env.deployrepo }}
         branch: ${{ inputs.preview-branch }}
         folder: ${{ inputs.source-dir }}
@@ -163,6 +173,7 @@ runs:
       uses: JamesIves/github-pages-deploy-action@65b5dfd4f5bcd3a7403bbc2959c144256167464e # v4.5.0
       with:
         token: ${{ env.token }}
+        ssh-key: ${{ inputs.ssh-key }}
         repository-name: ${{ env.deployrepo }}
         branch: ${{ inputs.preview-branch }}
         folder: ${{ env.emptydir }}

--- a/action.yml
+++ b/action.yml
@@ -76,6 +76,10 @@ inputs:
     description: Optional custom header for PR comments
     required: false
     default: ""
+  custom-message-suffix:
+    description: Optional string to append to the deployment comment
+    required: false
+    default: ""
 
 outputs:
   deployment-url:
@@ -165,6 +169,8 @@ runs:
 
           :rocket: Deployed preview to
           https://${{ env.pagesurl }}/${{ env.targetdir }}/
+          
+          ${{ inputs.custom-message-suffix }}
 
           on branch [`${{ inputs.preview-branch }}`](\
           ${{ github.server_url }}/${{ env.deployrepo }}\


### PR DESCRIPTION
This change adds two inputs to the action.

1. **custom-header** - allows you to pass a custom comment header, which enables us to leave separate staging site comments on the same pull request. This supports the Cyera work in the KB.
2. **custom-message-suffix** - allows you to pass a custom text block, which will be appended to the end of the staging site comment. This will allow us to include changed articles in the PR preview comment.
