### PR TITLE
Add customizable commit messages for deploy and destroy actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,14 +104,14 @@ Input&nbsp;parameter | Description
 `comment` <br> (boolean) | Whether to leave a [sticky comment](https://github.com/marocchino/sticky-pull-request-comment) on the PR after the preview is built.<br> The comment may be added before the preview finishes deploying. <br><br> Default: `true`
 `token` | Authentication token for the preview deployment. <br> The default value works for non-fork pull requests to the same repository. For anything else, you will need a [Personal Access Token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) with permission to access it, and [store it as a secret](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions) in your repository. E.g. you might name that secret 'PREVIEW_TOKEN' and use it with `token: ${{ secrets.PREVIEW_TOKEN }}`. <br><br> Default: `${{ github.token }}`, which gives the action permission to deploy to the current repository.
 `action` <br> (enum) | Determines what this action will do when it is executed. Supported values: <br><br> <ul><li>`deploy` - create and deploy the preview, overwriting any existing preview in that location.</li><li>`remove` - remove the preview.</li><li>`auto` - determine whether to deploy or remove the preview based on [the emitted event](https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#pull_request). If the event is `pull_request`, it will deploy the preview when the event type is `opened`, `reopened` and `synchronize`, and remove it on `closed` events. Does not do anything for other events or event types, even if you explicitly instruct the workflow to run on them.</li><li>`none` and all other values: does not do anything.</li></ul> Default: `auto`
-`deploy-commit-message` | Custom commit message for deploying the preview. <br> You can use GitHub context variables like `${{ github.event.number }}`. <br><br> Default: `Deploy preview for PR ${{ github.event.number }} 🛫`
-`remove-commit-message` | Custom commit message for removing the preview. <br> You can use GitHub context variables like `${{ github.event.number }}`. <br><br> Default: `Remove preview for PR ${{ github.event.number }} 🛬`
 
 <details>
 <summary><b>Extra parameters for controlling the commits</b></summary>
 
 | Input&nbsp;parameter | Description |
 | --- | --- |
+| `deploy-commit-message` | The commit message to use when adding/updating a preview. <br> You can use GitHub context variables like `${{ github.event.number }}`. <br><br> Default: `Deploy preview for PR ${{ github.event.number }} 🛫` |
+| `remove-commit-message` | The commit message to use when removing a preview. <br> Note: If using `action` with a value of `"auto"`, you need to specify BOTH `deploy-commit-message` and `remove-commit-message`. <br><br> Default: `Remove preview for PR ${{ github.event.number }} 🛬` |
 | `git-config-name` | The git user.name to use for the deployment commit. <br><br> Default: The user who created the `token` |
 | `git-config-email` | The git user.email to use for the deployment commit. <br><br> Default: The user who created the `token` |
 

--- a/action.yml
+++ b/action.yml
@@ -53,6 +53,14 @@ inputs:
     description: Whether to leave a sticky comment on the calling PR.
     required: false
     default: "true"
+  deploy-commit-message:
+    description: The commit message to use when adding/updating a preview.
+    required: false
+    default: Deploy preview for PR ${{ github.event.number }} 🛫
+  remove-commit-message:
+    description: The commit message to use when removing a preview.
+    required: false
+    default: Remove preview for PR ${{ github.event.number }} 🛬
   git-config-name:
     description: The git user.name to use for the deployment commit.
     required: false
@@ -83,18 +91,6 @@ inputs:
       all other events. `auto` is the default value.
     required: false
     default: auto
-  deploy-commit-message:
-    description: >
-      Custom commit message for deploying the preview.
-      You can use GitHub context variables like `${{ github.event.number }}`.
-    required: false
-    default: Deploy preview for PR ${{ github.event.number }} 🛫
-  remove-commit-message:
-    description: >
-      Custom commit message for removing the preview.
-      You can use GitHub context variables like `${{ github.event.number }}`.
-    required: false
-    default: Remove preview for PR ${{ github.event.number }} 🛬
 
 outputs:
   deployment-action:


### PR DESCRIPTION
This PR adds two new optional input parameters to allow users to customize the commit messages used when deploying and removing PR previews.

## Changes
New input parameters:
- deploy-commit-message: Customize the commit message when deploying a preview
- remove-commit-message: Customize the commit message when removing a preview