### PR TITLE
Fix: forward pr-number input to sticky-pull-request-comment

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -219,6 +219,7 @@ runs:
           uses: marocchino/sticky-pull-request-comment@67d0dec7b07ed060a405f9b2a64b8ab319fdd7db # v2.9.2
           with:
               header: pr-preview
+              number: ${{ env.pr_number || github.event.pull_request.number }}
               message: ${{ steps.deploy-comment.outputs.content }}
 
         # REMOVAL
@@ -290,4 +291,5 @@ runs:
           uses: marocchino/sticky-pull-request-comment@67d0dec7b07ed060a405f9b2a64b8ab319fdd7db # v2.9.2
           with:
               header: pr-preview
+              number: ${{ env.pr_number || github.event.pull_request.number }}
               message: ${{ steps.remove-comment.outputs.content }}


### PR DESCRIPTION
**Problem**

When using the action in a `workflow_run` triggered workflow, the `pr-number` input is correctly used for the deployment path, but it is not passed to the `sticky-pull-request-comment` step. As a result, the comment step is skipped with the following message:

`no pull request numbers given: skip step`

Example: https://github.com/eclipse-theia/theia-website/actions/runs/21430355423/job/61708044522#step:6:206

This issue occurs because `workflow_run` events do not provide `github.event.pull_request.number`, which `sticky-pull-request-comment` depends on by default.

**Fix**

Pass the `number` parameter to both `sticky-pull-request-comment` steps, with a fallback to maintain backwards compatibility: `number: ${{ env.pr_number || github.event.pull_request.number }}`

This ensures that:
- `workflow_run` workflows function correctly when `pr-number` is provided
- Existing `pull_request` and `pull_request_target` workflows continue to work without changes
