### PR TITLE
Add ssh-key input for SSH-based deployments

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,12 @@ inputs:
 
         required: false
         default: ${{ github.token }}
+    ssh-key:
+        description: >
+            A private SSH key to use for deployment via SSH, as an alternative to the token. Pass the key from a repository secret. The corresponding public key should be added as a deploy key with write access on the target repository.
+
+            Set to `true` to enable SSH endpoints without configuring the SSH client, if SSH has already been set up in a previous step.
+        required: false
     preview-branch:
         description: Branch on which the previews will be deployed.
         required: false
@@ -157,6 +163,7 @@ runs:
           uses: JamesIves/github-pages-deploy-action@4a3abc783e1a24aeb44c16e869ad83caf6b4cc23 # v4.7.4
           with:
               token: ${{ inputs.token }}
+              ssh-key: ${{ inputs.ssh-key }}
               repository-name: ${{ inputs.deploy-repository }}
               branch: ${{ inputs.preview-branch }}
               folder: ${{ inputs.source-dir }}
@@ -228,6 +235,7 @@ runs:
           uses: JamesIves/github-pages-deploy-action@4a3abc783e1a24aeb44c16e869ad83caf6b4cc23 # v4.7.4
           with:
               token: ${{ inputs.token }}
+              ssh-key: ${{ inputs.ssh-key }}
               repository-name: ${{ inputs.deploy-repository }}
               branch: ${{ inputs.preview-branch }}
               folder: ${{ env.empty_dir_path }}


### PR DESCRIPTION
## Summary

Passes through an `ssh-key` input to `JamesIves/github-pages-deploy-action` for both deploy and remove steps. This allows users to authenticate via a deploy key instead of a token, which is useful for cross-repository deployments or environments where SSH is preferred.

The input is optional and is a no-op when not provided, preserving existing behavior.

### Changes
- Added `ssh-key` input to `action.yml`
- Passed `ssh-key` to both the deploy and remove invocations of `github-pages-deploy-action`

## Context

We've been maintaining this as a fork addition at [datagrail/pr-preview-action](https://github.com/datagrail/pr-preview-action) and would like to contribute it upstream so we can stop carrying the patch.