### PR TITLE
fix: forward pr-number to sticky PR comments

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -219,6 +219,7 @@ runs:
           uses: marocchino/sticky-pull-request-comment@67d0dec7b07ed060a405f9b2a64b8ab319fdd7db # v2.9.2
           with:
               header: pr-preview
+              number: ${{ inputs.pr-number || github.event.number }}
               message: ${{ steps.deploy-comment.outputs.content }}
 
         # REMOVAL
@@ -290,4 +291,5 @@ runs:
           uses: marocchino/sticky-pull-request-comment@67d0dec7b07ed060a405f9b2a64b8ab319fdd7db # v2.9.2
           with:
               header: pr-preview
+              number: ${{ inputs.pr-number || github.event.number }}
               message: ${{ steps.remove-comment.outputs.content }}

--- a/test/unit/test-comment-content.sh
+++ b/test/unit/test-comment-content.sh
@@ -98,3 +98,29 @@ cat >&2 "$comment_file"
 echo >&2 "==============================="
 
 assert_file_contains "$comment_file" "qr.rossjrw.com"
+
+echo >&2 "test sticky comments: PR number forwarding"
+echo >&2 "==============================="
+action_file="$(dirname "$0")/../../action.yml"
+sticky_number='number: ${{ inputs.pr-number || github.event.number }}'
+
+assert_file_contains "$action_file" "$sticky_number" "Sticky comment action should receive PR number with fallback expression"
+
+count=$(grep -Ec '^[[:space:]]+number: \$\{\{ inputs\.pr-number \|\| github\.event\.number \}\}$' "$action_file")
+assert_equals "2" "$count"
+
+deploy_count=$(awk '
+    /^[[:space:]]*- name: Leave a comment after deployment$/ { in_step=1; next }
+    in_step && /^[[:space:]]*- name: / { in_step=0 }
+    in_step && /number: \$\{\{ inputs\.pr-number \|\| github.event.number \}\}/ { count++ }
+    END { print count + 0 }
+' "$action_file")
+assert_equals "1" "$deploy_count"
+
+remove_count=$(awk '
+    /^[[:space:]]*- name: Leave a comment after removal$/ { in_step=1; next }
+    in_step && /^[[:space:]]*- name: / { in_step=0 }
+    in_step && /number: \$\{\{ inputs\.pr-number \|\| github.event.number \}\}/ { count++ }
+    END { print count + 0 }
+' "$action_file")
+assert_equals "1" "$remove_count"


### PR DESCRIPTION
The `pr-number` input is already used by the action to resolve the preview path, but it was not forwarded to `sticky-pull-request-comment`.

This causes the preview deployment itself to succeed while the native comment can be skipped when the action runs outside a `pull_request` event, such as from `workflow_run`.